### PR TITLE
Uniqueness checks all active contracts

### DIFF
--- a/GameData/ContractPacks/SpaceJunk/JunkDestruction.cfg
+++ b/GameData/ContractPacks/SpaceJunk/JunkDestruction.cfg
@@ -90,8 +90,8 @@ CONTRACT_TYPE
 	DATA // Choose a piece of junk based on prestige level. If there isn't any at this level the contract won't be offered, this time
 	{
 		type = Vessel
-		uniquenessCheck = GROUP_ACTIVE 	// Don't have more than one active contract for the selected vessel. Avoids conflicting objectives
-		requiredValue = true 			// We must select a vessel. If not, this acts like a failed REQUIREMENT and the contract won't be offered
+		uniquenessCheck = CONTRACT_ACTIVE 	// Don't have more than one active contract for the selected vessel. Avoids conflicting objectives
+		requiredValue = true 				// We must select a vessel. If not, this acts like a failed REQUIREMENT and the contract won't be offered
 		title = Must destroy a specific piece of junk
 		targetVessel = Prestige() == Trivial ? @/targetVessel1 : Prestige() == Significant ? @/targetVessel2 : @/targetVessel3
 	}

--- a/GameData/ContractPacks/SpaceJunk/JunkRecovery.cfg
+++ b/GameData/ContractPacks/SpaceJunk/JunkRecovery.cfg
@@ -90,8 +90,8 @@ CONTRACT_TYPE
 	DATA // Choose a piece of junk based on prestige level. If there isn't any at this level the contract won't be offered, this time
 	{
 		type = Vessel
-		uniquenessCheck = GROUP_ACTIVE 	// Don't have more than one active contract for the selected vessel. Avoids conflicting objectives
-		requiredValue = true 			// We must select a vessel. If not, this acts like a failed REQUIREMENT and the contract won't be offered
+		uniquenessCheck = CONTRACT_ACTIVE 	// Don't have more than one active contract for the selected vessel. Avoids conflicting objectives
+		requiredValue = true 				// We must select a vessel. If not, this acts like a failed REQUIREMENT and the contract won't be offered
 		title = Must recover a specific piece of junk		
 		targetVessel = Prestige() == Trivial ? @/targetVessel1 : Prestige() == Significant ? @/targetVessel2 : @/targetVessel3
 	}

--- a/GameData/ContractPacks/SpaceJunk/SpaceJunk.version
+++ b/GameData/ContractPacks/SpaceJunk/SpaceJunk.version
@@ -10,7 +10,7 @@
  "VERSION":{
      "MAJOR":1,
      "MINOR":3,
-     "PATCH":0,
+     "PATCH":1,
      "BUILD":0
  },
  "KSP_VERSION":{


### PR DESCRIPTION
Changed GROUP_ACTIVE to CONTRACT_ACTIVE, to ensure that the selected
debris with unique within all active contracts. Closes #10